### PR TITLE
Add selectable database readers with optional mmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.1.2
+
+- Added multiple database readers: standard `BufReader`, optional `mmap` (feature), and in-memory loading.
+
 ## v0.1.1
 
 - Fixed several bugs to improve stability.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,14 @@ description = "A pure Rust library for parsing CZDB-format IP databases."
 
 [dependencies]
 base64 = "0.22.1"
-memmap2 = "0.9.5"
+memmap2 = { version = "0.9.5", optional = true }
 rmpv = "1.3.0"
 thiserror = "2.0.3"
 aes = "=0.8.3"
 cipher = { version = "=0.4.4", features = ["block-padding"] }
 chrono = "0.4.38"
 byteorder = "1.5.0"
+
+[features]
+default = []
+mmap = ["memmap2"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://docs.rs/czdb)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/AldenClark/czdb-rs/blob/main/LICENSE-MIT)
 
-czdb-rs is a simple and fast Rust library for parsing CZDB-format IP databases. It supports both IPv4 and IPv6 lookups and uses memory-mapped files (mmap) to keep memory usage low and speed up disk access. Perfect for quick IP geolocation queries with minimal overhead.
+czdb-rs is a simple and fast Rust library for parsing CZDB-format IP databases. It supports both IPv4 and IPv6 lookups. By default it reads databases using a buffered reader, with optional memory-mapped (`mmap` feature) and fully in-memory loading strategies for faster access or lower overhead.
 
 Note: The database file and key must be obtained from [www.cz88.net](https://cz88.net/geo-public).
 
@@ -13,6 +13,10 @@ Note: The database file and key must be obtained from [www.cz88.net](https://cz8
 ```bash
 cargo add czdb
 ```
+
+### Features
+
+- `mmap` — enable memory-mapped file loading.
 
 ```rust
 use czdb::Czdb;


### PR DESCRIPTION
## Summary
- support three database readers: buffered, memory-mapped (via feature), and in-memory
- make memmap optional and document `mmap` feature
- update docs and changelog for new loading strategies

## Testing
- `cargo test`
- `cargo test --features mmap`


------
https://chatgpt.com/codex/tasks/task_e_68bc048d06348323a4211f42d89e5204